### PR TITLE
GJI-7 - create ns with given resourcequota

### DIFF
--- a/GJI-7.md
+++ b/GJI-7.md
@@ -1,0 +1,3 @@
+# GJI-7
+
+This file was auto-generated for Jira issue GJI-7.


### PR DESCRIPTION
This PR is linked to Jira issue [GJI-7](https://ujjawalkhare.atlassian.net/browse/GJI-7)

/jira

please create a namespace in eks with below resourcequota:

```
apiVersion: v1
kind: ResourceQuota
metadata:
  name: mem-cpu-demo
spec:
  hard:
    requests.cpu: "1"
    requests.memory: 1Gi
    limits.cpu: "2"
    limits.memory: 2Gi
```

[GJI-7]: https://ujjawalkhare.atlassian.net/browse/GJI-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ