### PR TITLE
GJI-8 - Please create a new namespace in dev eks cluster

### DIFF
--- a/GJI-8.md
+++ b/GJI-8.md
@@ -1,0 +1,3 @@
+# GJI-8
+
+This file was auto-generated for Jira issue GJI-8.


### PR DESCRIPTION
This PR is linked to Jira issue [GJI-8](https://ujjawalkhare.atlassian.net/browse/GJI-8)

/jira

please create a namespace in eks with below resourcequota:

apiVersion: v1
kind: ResourceQuota
metadata:
  name: mem-cpu-demo
spec:
  hard:
    requests.cpu: "1"
    requests.memory: 1Gi
    limits.cpu: "2"
    limits.memory: 2Gi

[GJI-8]: https://ujjawalkhare.atlassian.net/browse/GJI-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ