### PR TITLE
GJI-9 - Please create a new namespace in dev eks cluster

### DIFF
--- a/GJI-9.md
+++ b/GJI-9.md
@@ -1,0 +1,3 @@
+# GJI-9
+
+This file was auto-generated for Jira issue GJI-9.


### PR DESCRIPTION
This PR is linked to Jira issue [GJI-9](https://ujjawalkhare.atlassian.net/browse/GJI-9)

/jira

please create a namespace in eks with below resourcequota...:

apiVersion: v1
kind: ResourceQuota
metadata:
  name: mem-cpu-demo
spec:
  hard:
    requests.cpu: "1"
    requests.memory: 1Gi
    limits.cpu: "2"
    limits.memory: 2Gi

[GJI-9]: https://ujjawalkhare.atlassian.net/browse/GJI-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ