### PR TITLE
GJI-11 - Please create a new namespace in dev eks cluster

### DIFF
--- a/GJI-11.md
+++ b/GJI-11.md
@@ -1,0 +1,3 @@
+# GJI-11
+
+This file was auto-generated for Jira issue GJI-11.


### PR DESCRIPTION
This PR is linked to Jira issue [GJI-11](https://ujjawalkhare.atlassian.net/browse/GJI-11)

/jira

please create a namespace in eks with below resourcequota...:

apiVersion: v1
kind: ResourceQuota
metadata:
name: mem-cpu-demo
spec:
hard:
requests.cpu: "1"
requests.memory: 1Gi
limits.cpu: "2"
limits.memory: 2Gi

[GJI-11]: https://ujjawalkhare.atlassian.net/browse/GJI-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ