### PR TITLE
GJI-12 - Please create a new namespace in dev eks cluster

### DIFF
--- a/GJI-12.md
+++ b/GJI-12.md
@@ -1,0 +1,3 @@
+# GJI-12
+
+This file was auto-generated for Jira issue GJI-12.


### PR DESCRIPTION
This PR is linked to Jira issue [GJI-12](https://ujjawalkhare.atlassian.net/browse/GJI-12)

/jira

please create a namespace in eks with below resourcequota...:

apiVersion: v1
kind: ResourceQuota
metadata:
name: mem-cpu-demo
spec:
hard:
requests.cpu: "1"
requests.memory: 1Gi
limits.cpu: "2"
limits.memory: 2Gi

[GJI-12]: https://ujjawalkhare.atlassian.net/browse/GJI-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ