### PR TITLE
GJI-27 - eks workspace

### DIFF
--- a/GJI-27.md
+++ b/GJI-27.md
@@ -1,0 +1,3 @@
+# GJI-27
+
+This file was auto-generated for Jira issue GJI-27.


### PR DESCRIPTION
This PR is linked to Jira issue [GJI-27](https://ujjawalkhare.atlassian.net/browse/GJI-27)

/jira

please create eks ns with below quota

apiVersion: v1
kind: ResourceQuota
metadata:
  name: mem-cpu-demo
spec:
  hard:
    requests.cpu: "1"
    requests.memory: 1Gi
    limits.cpu: "2"
    limits.memory: 2Gi

[GJI-27]: https://ujjawalkhare.atlassian.net/browse/GJI-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ