### PR TITLE
GJI-30 - eks workspace

### DIFF
--- a/GJI-30.md
+++ b/GJI-30.md
@@ -1,0 +1,5 @@
+# GJI-30
+
+This file was auto-generated for Jira issue GJI-30.
+
+GitHub Issue: #55


### PR DESCRIPTION
This PR is linked to Jira issue [GJI-30](https://ujjawalkhare.atlassian.net/browse/GJI-30)

GitHub Issue: #55

/jira

please create eks ns with below quota

apiVersion: v1
kind: ResourceQuota
metadata:
name: mem-cpu-demo
spec:
hard:
requests.cpu: "1"
requests.memory: 1Gi
limits.cpu: "2"
limits.memory: 2Gi

[GJI-30]: https://ujjawalkhare.atlassian.net/browse/GJI-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ