### PR TITLE
GJI-31 - create new ns for dev

### DIFF
--- a/GJI-31.md
+++ b/GJI-31.md
@@ -1,0 +1,5 @@
+# GJI-31
+
+This file was auto-generated for Jira issue GJI-31.
+
+GitHub Issue: #39


### PR DESCRIPTION
This PR is linked to Jira issue [GJI-31](https://ujjawalkhare.atlassian.net/browse/GJI-31)

GitHub Issue: #39

/jira

please create a namespace in eks with below resourcequota:

apiVersion: v1
kind: ResourceQuota
metadata:
name: mem-cpu-demo
spec:
hard:
requests.cpu: "1"
requests.memory: 1Gi
limits.cpu: "2"
limits.memory: 2Gi

[GJI-31]: https://ujjawalkhare.atlassian.net/browse/GJI-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ